### PR TITLE
Add support for Maven Central requirements

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,8 @@ jobs:
         java-version: '21'
         distribution: 'adopt'
         cache: maven
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg-passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
     - name: Cache local Maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,4 +30,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: mvn -B verify
+      run: mvn --non-interactive verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,8 +22,6 @@ jobs:
         java-version: '21'
         distribution: 'adopt'
         cache: maven
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-        gpg-passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
     - name: Cache local Maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,4 +30,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: mvn --non-interactive verify
+      run: mvn -B verify

--- a/.github/workflows/release-to-central.yml
+++ b/.github/workflows/release-to-central.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mvn \
             -Ppublish-to-central \
-            --non-interactive \
+            -B \
             deploy
       - name: Set up for publishing to GitHub Packages
         uses: actions/setup-java@v4

--- a/.github/workflows/release-to-central.yml
+++ b/.github/workflows/release-to-central.yml
@@ -1,0 +1,48 @@
+name: Publish artifact to Maven Central
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: Set for publishing to Maven Central
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'adopt'
+          cache: maven
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish to Central Repository
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          mvn \
+            -Ppublish-to-central \
+            --non-interactive \
+            deploy
+      - name: Set up for publishing to GitHub Packages
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'adopt'
+          server-id: github
+          cache: maven
+      - name: Publish to GitHub Packages
+        run: |
+          mvn \
+            -Ppublish-to-github \
+            --non-interactive \
+            deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-to-central.yml
+++ b/.github/workflows/release-to-central.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mvn \
             -Ppublish-to-github \
-            --non-interactive \
+            -B \
             deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-to-central.yml
+++ b/.github/workflows/release-to-central.yml
@@ -12,7 +12,7 @@ jobs:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
       - name: Set for publishing to Maven Central
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'adopt'

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     </properties>
 
 
@@ -179,6 +180,24 @@
                         <id>help-mojo</id>
                         <goals>
                             <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <configuration>
+                    <!-- finalName appends '-sources' already which is required for Maven Central-->
+                    <finalName>${artifactId}-${version}</finalName>
+                    <attach>false</attach>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-sources</id>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     </properties>
 
 
@@ -193,6 +195,11 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${maven-resources-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -241,6 +248,19 @@
                         <id>generate-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven-gpg-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <goals>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,13 @@
     </description>
     <url>https://github.com/giovds/outdated-maven-plugin/</url>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
     <properties>
         <maven-plugin-tools.version>3.13.1</maven-plugin-tools.version>
         <maven.compiler.release>21</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
     </properties>
 
 
@@ -196,6 +197,25 @@
                 <executions>
                     <execution>
                         <id>generate-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <!-- Exclude generating docs for generated class by maven-plugin-plugin:helpmojo -->
+                    <excludePackageNames>*.outdated_maven_plugin</excludePackageNames>
+                    <!-- finalName appends '-javadoc' already which is required for Maven Central-->
+                    <finalName>${artifactId}-${version}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-javadocs</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -222,10 +222,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${maven-source-plugin.version}</version>
-                <configuration>
-                    <!-- finalName appends '-sources' already which is required for Maven Central-->
-                    <finalName>${project.artifactId}-${project.version}</finalName>
-                </configuration>
                 <executions>
                     <execution>
                         <id>generate-sources</id>
@@ -242,8 +238,6 @@
                 <configuration>
                     <!-- Exclude generating docs for generated class by maven-plugin-plugin:helpmojo -->
                     <excludePackageNames>*.outdated_maven_plugin</excludePackageNames>
-                    <!-- finalName appends '-javadoc' already which is required for Maven Central-->
-                    <finalName>${project.artifactId}-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,13 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <name>Giovanni van der Schelde</name>
+            <url>https://github.com/Giovds</url>
+        </developer>
+    </developers>
+
     <properties>
         <maven-plugin-tools.version>3.13.1</maven-plugin-tools.version>
         <maven.compiler.release>21</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -267,4 +267,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>publish-to-github</id>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/octocat/hello-world</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>publish-to-central</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Maven Central</name>
+                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,16 @@
     </description>
     <url>https://github.com/giovds/outdated-maven-plugin/</url>
 
+    <scm>
+        <connection>scm:git:git://github.com/Giovds/outdated-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://github.com:Giovds/outdated-maven-plugin.git</developerConnection>
+        <url>https://github.com/Giovds/outdated-maven-plugin/tree/main</url>
+    </scm>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/Giovds/outdated-maven-plugin/issues</url>
+    </issueManagement>
+
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,12 @@
     <packaging>maven-plugin</packaging>
 
     <name>The Outdated Maven Plugin</name>
+    <description>The Outdated Maven Plugin is a tool designed to help developers identify outdated dependencies in their
+        Maven projects. By scanning the dependencies of your project, this plugin determines if they are no longer
+        actively maintained based on a user-defined threshold of inactivity in years. This ensures that your project
+        remains up-to-date with the latest and most secure versions of its dependencies.
+    </description>
+    <url>https://github.com/giovds/outdated-maven-plugin/</url>
 
     <properties>
         <maven-plugin-tools.version>3.13.1</maven-plugin-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
                 <repository>
                     <id>github</id>
                     <name>GitHub Packages</name>
-                    <url>https://maven.pkg.github.com/octocat/hello-world</url>
+                    <url>https://maven.pkg.github.com/giovds/outdated-maven-plugin</url>
                 </repository>
             </distributionManagement>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,6 @@
                 <configuration>
                     <!-- finalName appends '-sources' already which is required for Maven Central-->
                     <finalName>${artifactId}-${version}</finalName>
-                    <attach>false</attach>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <maven-plugin-tools.version>3.13.1</maven-plugin-tools.version>
         <maven.compiler.release>21</maven.compiler.release>
         <jackson-jr-objects.version>2.17.2</jackson-jr-objects.version>
@@ -222,7 +224,7 @@
                 <version>${maven-source-plugin.version}</version>
                 <configuration>
                     <!-- finalName appends '-sources' already which is required for Maven Central-->
-                    <finalName>${artifactId}-${version}</finalName>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>
@@ -241,26 +243,13 @@
                     <!-- Exclude generating docs for generated class by maven-plugin-plugin:helpmojo -->
                     <excludePackageNames>*.outdated_maven_plugin</excludePackageNames>
                     <!-- finalName appends '-javadoc' already which is required for Maven Central-->
-                    <finalName>${artifactId}-${version}</finalName>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>
                         <id>generate-javadocs</id>
                         <goals>
                             <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <goals>
-                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -278,6 +267,23 @@
                     <url>https://maven.pkg.github.com/giovds/outdated-maven-plugin</url>
                 </repository>
             </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>publish-to-central</id>
@@ -292,6 +298,23 @@
                     <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/com/giovds/DependenciesToQueryMapper.java
+++ b/src/main/java/com/giovds/DependenciesToQueryMapper.java
@@ -5,10 +5,20 @@ import org.apache.maven.model.Dependency;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+/**
+ * Converts Maven {@link Dependency} to a single Lucene query that can be sent to Maven Central.
+ * This in order to not spam the endpoint with a request per dependency.
+ */
 public class DependenciesToQueryMapper {
+    private DependenciesToQueryMapper() {
+    }
+
     /**
      * Create a <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html">Lucene</a> query from
      * a collection of {@link org.apache.maven.project.MavenProject} {@link Dependency}
+     *
+     * @param dependencies A collection of Maven {@link Dependency} to convert to query params
+     * @return A Lucene query as {@link String} with spaces escaped by '+'
      */
     public static String map(final Collection<Dependency> dependencies) {
         return dependencies

--- a/src/main/java/com/giovds/QueryClient.java
+++ b/src/main/java/com/giovds/QueryClient.java
@@ -17,6 +17,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Search Maven Central with a Lucene query
+ */
 public class QueryClient {
     private final String main_uri;
 
@@ -27,10 +30,20 @@ public class QueryClient {
         this.main_uri = uri;
     }
 
+    /**
+     * Defaults to connect to actual Maven Central endpoint
+     */
     public QueryClient() {
         this("https://search.maven.org/solrsearch/select");
     }
 
+    /**
+     * Send a GET request to Maven Central with the provided query to
+     *
+     * @param query The Lucene query as {@link String}
+     * @return A set of dependencies returned by Maven Central mapped to {@link FoundDependency}
+     * @throws MojoExecutionException when something failed when sending the request
+     */
     public Set<FoundDependency> search(final String query) throws MojoExecutionException {
         try (final HttpClient client = HttpClient.newHttpClient()) {
             final HttpRequest request = buildHttpRequest(query);
@@ -73,10 +86,19 @@ public class QueryClient {
 
     }
 
+    /**
+     * The dependency returned by the Maven Central response
+     *
+     * @param id        GAV (groupId:artifactId:version)
+     * @param g         groupId
+     * @param a         artifactId
+     * @param v         version
+     * @param timestamp The date this GAV id was released to Maven Central
+     */
     public record FoundDependency(String id, String g, String a, String v, LocalDate timestamp) {
     }
 
-    public static FoundDependency mapToSearch(Map<String, Object> doc) {
+    static FoundDependency mapToSearch(Map<String, Object> doc) {
         return new FoundDependency(
                 (String) doc.get("id"),
                 (String) doc.get("g"),


### PR DESCRIPTION
To make the plugin publicly accessible publishing it to Maven Central is a good step.

In order to make this work the package has to comply to the following requirements: https://central.sonatype.org/publish/requirements

This PR aims to support this and closes issue #7.