### PR TITLE
Work around the limited Sonatype API responses

### DIFF
--- a/src/main/java/com/giovds/DependenciesToQueryMapper.java
+++ b/src/main/java/com/giovds/DependenciesToQueryMapper.java
@@ -44,13 +44,17 @@ public class DependenciesToQueryMapper {
         }
 
         removeTrailingJoin(query);
-        result.add(query.toString());
+        if (!query.isEmpty()) {
+            result.add(query.toString());
+        }
 
         return result;
     }
 
     private static void removeTrailingJoin(final StringBuilder query) {
-        query.setLength(query.length() - JOIN_CHARS.length());
+        if (query.length() > JOIN_CHARS.length()) {
+            query.setLength(query.length() - JOIN_CHARS.length());
+        }
     }
 
     private static boolean isWithinMaxLength(final int maxQueryLength, final StringBuilder query, final String nextQueryParam) {

--- a/src/main/java/com/giovds/OutdatedMavenPluginMojo.java
+++ b/src/main/java/com/giovds/OutdatedMavenPluginMojo.java
@@ -52,12 +52,14 @@ public class OutdatedMavenPluginMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final List<String> queryForAllDependencies = DependenciesToQueryMapper.mapToQueries(project.getDependencies());
+        final List<Dependency> dependencies = project.getDependencies();
 
-        if (queryForAllDependencies.isEmpty()) {
+        if (dependencies.isEmpty()) {
             // When building a POM without any dependencies there will be nothing to query.
             return;
         }
+
+        final List<String> queryForAllDependencies = DependenciesToQueryMapper.mapToQueries(dependencies);
 
         final Set<QueryClient.FoundDependency> result = client.search(queryForAllDependencies);
 

--- a/src/main/java/com/giovds/OutdatedMavenPluginMojo.java
+++ b/src/main/java/com/giovds/OutdatedMavenPluginMojo.java
@@ -52,7 +52,7 @@ public class OutdatedMavenPluginMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final List<String> queryForAllDependencies = DependenciesToQueryMapper.mapToQueries(client.getMaximumRequestLength(), project.getDependencies());
+        final List<String> queryForAllDependencies = DependenciesToQueryMapper.mapToQueries(project.getDependencies());
 
         if (queryForAllDependencies.isEmpty()) {
             // When building a POM without any dependencies there will be nothing to query.

--- a/src/main/java/com/giovds/QueryClient.java
+++ b/src/main/java/com/giovds/QueryClient.java
@@ -71,16 +71,6 @@ public class QueryClient {
                 .build();
     }
 
-    /**
-     * Large projects can have lots of dependencies which results in exceeding the max length of a GET request.
-     * <a href="https://github.com/Giovds/outdated-maven-plugin/issues/24">For more info checkout the issue</a>
-     * @return The maximum allowed length of the query parameters for one request.
-     */
-    int getMaximumRequestLength() {
-        final int queryFormatLength = 11; // ?q= and &wt=json
-        return MAX_URL_LENGTH - this.main_uri.length() + queryFormatLength;
-    }
-
     private static class SearchResponseBodyHandler implements HttpResponse.BodyHandler<Set<FoundDependency>> {
         @Override
         public HttpResponse.BodySubscriber<Set<FoundDependency>> apply(final HttpResponse.ResponseInfo responseInfo) {

--- a/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
+++ b/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
@@ -1,6 +1,8 @@
 package com.giovds;
 
 import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DependenciesToQueryMapperTest {
 
     @Test

--- a/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
+++ b/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
@@ -3,7 +3,10 @@ package com.giovds;
 import org.apache.maven.model.Dependency;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -16,7 +19,7 @@ class DependenciesToQueryMapperTest {
         final var firstDep = createDependency("com.giovds", "foo-artifact", "1.0.0");
         final var secondDep = createDependency("org.apache.maven", "bar-artifact", "1.2.3");
 
-        final List<String> actualQuery = DependenciesToQueryMapper.mapToQueries(2000, List.of(firstDep, secondDep));
+        final List<String> actualQuery = DependenciesToQueryMapper.mapToQueries(List.of(firstDep, secondDep));
 
         assertThat(actualQuery).hasSize(1)
                 .contains(expectedUriQuery);
@@ -25,15 +28,18 @@ class DependenciesToQueryMapperTest {
     @Test
     void should_return_multiple_lucene_query_based_on_given_dependencies_when_exceeding_limit() {
         final var firstDep = createDependency("com.giovds", "foo-artifact", "1.0.0");
-        final var firstExpectedQuery = "(g:com.giovds AND a:foo-artifact AND v:1.0.0)";
-        final var secondDep = createDependency("org.apache.maven", "bar-artifact", "1.2.3");
-        final var secondExpectedQuery = "(g:org.apache.maven AND a:bar-artifact AND v:1.2.3)";
+        final var otherDeps = IntStream.rangeClosed(1, 25)
+                .mapToObj(i -> String.format("bar-artifact-%d", i))
+                .map(artifactId -> createDependency("org.apache.maven", artifactId, "1.2.3"))
+                .collect(Collectors.toSet());
 
-        final List<String> actualQuery = DependenciesToQueryMapper.mapToQueries(50, List.of(firstDep, secondDep));
+        final var allDependencies = new ArrayList<Dependency>();
+        allDependencies.add(firstDep);
+        allDependencies.addAll(otherDeps);
 
-        assertThat(actualQuery).hasSize(2)
-                .contains(firstExpectedQuery.replace(' ', '+'),
-                        secondExpectedQuery.replace(' ', '+'));
+        final List<String> actualQueries = DependenciesToQueryMapper.mapToQueries(allDependencies);
+
+        assertThat(actualQueries).hasSize(2).allMatch(query -> query.endsWith(")"));
     }
 
     private Dependency createDependency(String groupId, String artifactId, String version) {

--- a/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
+++ b/src/test/java/com/giovds/DependenciesToQueryMapperTest.java
@@ -4,8 +4,9 @@ import org.apache.maven.model.Dependency;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -28,21 +29,18 @@ class DependenciesToQueryMapperTest {
                 .contains(expectedUriQuery);
     }
 
-    @Test
-    void should_return_multiple_lucene_query_based_on_given_dependencies_when_exceeding_limit() {
-        final var firstDep = createDependency("com.giovds", "foo-artifact", "1.0.0");
-        final var otherDeps = IntStream.rangeClosed(1, 25)
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 19, 20, 25, 30, 40, 59, 60})
+    void should_return_multiple_lucene_query_based_on_given_dependencies_when_exceeding_limit(final int numberOfDeps) {
+        final var dependencies = IntStream.rangeClosed(1, numberOfDeps)
                 .mapToObj(i -> String.format("bar-artifact-%d", i))
                 .map(artifactId -> createDependency("org.apache.maven", artifactId, "1.2.3"))
                 .collect(Collectors.toSet());
 
-        final var allDependencies = new ArrayList<Dependency>();
-        allDependencies.add(firstDep);
-        allDependencies.addAll(otherDeps);
+        final var actualQueries = DependenciesToQueryMapper.mapToQueries(dependencies);
 
-        final List<String> actualQueries = DependenciesToQueryMapper.mapToQueries(allDependencies);
-
-        assertThat(actualQueries).hasSize(2).allMatch(query -> query.endsWith(")"));
+        final var expectedQueryCount = (int) Math.ceil((double) numberOfDeps / 20);
+        assertThat(actualQueries).hasSize(expectedQueryCount).allMatch(query -> query.endsWith(")"));
     }
 
     private Dependency createDependency(String groupId, String artifactId, String version) {

--- a/src/test/java/com/giovds/OutdatedMavenPluginMojoTest.java
+++ b/src/test/java/com/giovds/OutdatedMavenPluginMojoTest.java
@@ -55,7 +55,6 @@ class OutdatedMavenPluginMojoTest {
         project.setDependencies(Collections.emptyList());
         mojo.setProject(project);
 
-        assertThatCode(() -> mojo.execute()).doesNotThrowAnyException();
         verify(client, never()).search(anyList());
     }
 

--- a/src/test/java/com/giovds/OutdatedMavenPluginMojoTest.java
+++ b/src/test/java/com/giovds/OutdatedMavenPluginMojoTest.java
@@ -4,7 +4,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -30,11 +29,6 @@ class OutdatedMavenPluginMojoTest {
 
     @InjectMocks
     private OutdatedMavenPluginMojo mojo = new OutdatedMavenPluginMojo(client);
-
-    @BeforeEach
-    void setUp() {
-        when(client.getMaximumRequestLength()).thenReturn(QueryClient.MAX_URL_LENGTH);
-    }
 
     @Test
     void should_throw_exception_when_shouldFailBuild_and_outdatedDependencies() throws Exception {


### PR DESCRIPTION
The API never returns more than 20 items. The code now chunks queries to ask for at most 20 items per query.

Fixes #49.