### PR TITLE
fix: resolve Jackson JR record deserialization issue and remove manua…

### DIFF
--- a/src/main/java/com/giovds/AverageAgeMojo.java
+++ b/src/main/java/com/giovds/AverageAgeMojo.java
@@ -88,7 +88,7 @@ public class AverageAgeMojo extends AbstractMojo {
     }
 
     private long calculateDependencyAge(DependencyResponse dependency) {
-        var between = Period.between(dependency.getDateTime(), today);
+        var between = Period.between(DependencyResponse.getDateTime(dependency.timestamp()), today);
         return 365L * between.getYears() + (between.getMonths() * 365L / 12L) + between.getDays();
     }
 

--- a/src/main/java/com/giovds/AverageAgeMojo.java
+++ b/src/main/java/com/giovds/AverageAgeMojo.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.giovds.dto.DependencyResponse.getDateTime;
+
 /**
  * This plugin goal prints the total and average age of all project dependencies. It excludes dependencies with the
  * same <pre>groupId</pre> (assuming they are part of the same project, they would skew the outcome).
@@ -88,7 +90,7 @@ public class AverageAgeMojo extends AbstractMojo {
     }
 
     private long calculateDependencyAge(DependencyResponse dependency) {
-        var between = Period.between(DependencyResponse.getDateTime(dependency.timestamp()), today);
+        var between = Period.between(getDateTime(dependency.timestamp()), today);
         return 365L * between.getYears() + (between.getMonths() * 365L / 12L) + between.getDays();
     }
 

--- a/src/main/java/com/giovds/CheckMojo.java
+++ b/src/main/java/com/giovds/CheckMojo.java
@@ -68,7 +68,7 @@ public class CheckMojo extends AbstractMojo {
         for (final Dependency currentDependency : project.getDependencies()) {
             result.stream()
                     .filter(dep -> currentDependency.getGroupId().equals(dep.g()) && currentDependency.getArtifactId().equals(dep.a()))
-                    .filter(dep -> dep.getDateTime().isBefore(LocalDate.now().minusYears(years)))
+                    .filter(dep -> DependencyResponse.getDateTime(dep.timestamp()).isBefore(LocalDate.now().minusYears(years)))
                     .findAny()
                     .ifPresent(outdatedDependencies::add);
         }
@@ -85,7 +85,7 @@ public class CheckMojo extends AbstractMojo {
     private void logWarning(final DependencyResponse dep) {
         final String message =
                 String.format("Dependency '%s' has not received an update since version '%s' was last uploaded '%s'.",
-                        dep.id(), dep.v(), dep.getDateTime());
+                        dep.id(), dep.v(), DependencyResponse.getDateTime(dep.timestamp()));
         if (shouldFailBuild) {
             getLog().error(message);
         } else {

--- a/src/main/java/com/giovds/CheckMojo.java
+++ b/src/main/java/com/giovds/CheckMojo.java
@@ -17,6 +17,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static com.giovds.dto.DependencyResponse.getDateTime;
+
 /**
  * This plugin goal determines if the project dependencies are no longer actively maintained
  * based on a user-defined threshold of inactivity in years.
@@ -68,7 +70,7 @@ public class CheckMojo extends AbstractMojo {
         for (final Dependency currentDependency : project.getDependencies()) {
             result.stream()
                     .filter(dep -> currentDependency.getGroupId().equals(dep.g()) && currentDependency.getArtifactId().equals(dep.a()))
-                    .filter(dep -> DependencyResponse.getDateTime(dep.timestamp()).isBefore(LocalDate.now().minusYears(years)))
+                    .filter(dep -> getDateTime(dep.timestamp()).isBefore(LocalDate.now().minusYears(years)))
                     .findAny()
                     .ifPresent(outdatedDependencies::add);
         }
@@ -85,7 +87,7 @@ public class CheckMojo extends AbstractMojo {
     private void logWarning(final DependencyResponse dep) {
         final String message =
                 String.format("Dependency '%s' has not received an update since version '%s' was last uploaded '%s'.",
-                        dep.id(), dep.v(), DependencyResponse.getDateTime(dep.timestamp()));
+                        dep.id(), dep.v(), getDateTime(dep.timestamp()));
         if (shouldFailBuild) {
             getLog().error(message);
         } else {

--- a/src/main/java/com/giovds/dto/DependencyResponse.java
+++ b/src/main/java/com/giovds/dto/DependencyResponse.java
@@ -1,5 +1,8 @@
 package com.giovds.dto;
 
+import com.fasterxml.jackson.jr.ob.JSON;
+
+import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -23,6 +26,20 @@ public record DependencyResponse(String id, String g, String a, String v, long t
      * @return A {@link DependencyResponse} object
      */
     public static DependencyResponse mapResponseToDependency(final Map<String, Object> doc) {
+
+
+//        try {
+//            System.out.println("String JSON   "+JSON.std.asString(doc));
+//            DependencyResponse response = JSON.std.beanFrom(DependencyResponse.class, JSON.std.asString(doc));
+//            System.out.println("Map output  " + response);
+//            return response;
+//        } catch (IOException e) {
+//            String errorMessage = "Error mapping response: " + e.getMessage();
+//            System.err.println(errorMessage);
+//            throw new RuntimeException(errorMessage);
+//        }
+
+
         return new DependencyResponse(
                 (String) doc.get("id"),
                 (String) doc.get("g"),

--- a/src/main/java/com/giovds/dto/DependencyResponse.java
+++ b/src/main/java/com/giovds/dto/DependencyResponse.java
@@ -1,12 +1,8 @@
 package com.giovds.dto;
 
-import com.fasterxml.jackson.jr.ob.JSON;
-
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Map;
 
 /**
  * The dependency returned by the Maven Central response
@@ -18,26 +14,6 @@ import java.util.Map;
  * @param timestamp The date this GAV id was released to Maven Central
  */
 public record DependencyResponse(String id, String g, String a, String v, long timestamp) {
-
-    /**
-     * Map the response from Maven Central to a {@link DependencyResponse}
-     *
-     * @param doc The response from Maven Central
-     * @return A {@link DependencyResponse} object
-     */
-    public static DependencyResponse mapResponseToDependency(final Map<String, Object> doc) {
-
-        try {
-            DependencyResponse response = JSON.std.beanFrom(DependencyResponse.class, JSON.std.asString(doc));
-            return response;
-        } catch (IOException e) {
-            String errorMessage = "Error mapping response: " + e.getMessage();
-            System.err.println(errorMessage);
-            throw new RuntimeException(errorMessage);
-        }
-
-    }
-
     /**
      * Return the timestamp as {@link LocalDate}
      *

--- a/src/main/java/com/giovds/dto/DependencyResponse.java
+++ b/src/main/java/com/giovds/dto/DependencyResponse.java
@@ -27,34 +27,24 @@ public record DependencyResponse(String id, String g, String a, String v, long t
      */
     public static DependencyResponse mapResponseToDependency(final Map<String, Object> doc) {
 
+        try {
+            DependencyResponse response = JSON.std.beanFrom(DependencyResponse.class, JSON.std.asString(doc));
+            return response;
+        } catch (IOException e) {
+            String errorMessage = "Error mapping response: " + e.getMessage();
+            System.err.println(errorMessage);
+            throw new RuntimeException(errorMessage);
+        }
 
-//        try {
-//            System.out.println("String JSON   "+JSON.std.asString(doc));
-//            DependencyResponse response = JSON.std.beanFrom(DependencyResponse.class, JSON.std.asString(doc));
-//            System.out.println("Map output  " + response);
-//            return response;
-//        } catch (IOException e) {
-//            String errorMessage = "Error mapping response: " + e.getMessage();
-//            System.err.println(errorMessage);
-//            throw new RuntimeException(errorMessage);
-//        }
-
-
-        return new DependencyResponse(
-                (String) doc.get("id"),
-                (String) doc.get("g"),
-                (String) doc.get("a"),
-                (String) doc.get("v"),
-                (long) doc.get("timestamp")
-        );
     }
 
     /**
      * Return the timestamp as {@link LocalDate}
      *
+     * @param timestamp the timestamp to convert
      * @return the {@link LocalDate}
      */
-    public LocalDate getDateTime() {
+    public static LocalDate getDateTime(long timestamp) {
         return Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalDate();
     }
 }

--- a/src/main/java/com/giovds/dto/MavenCentralResponse.java
+++ b/src/main/java/com/giovds/dto/MavenCentralResponse.java
@@ -1,0 +1,8 @@
+package com.giovds.dto;
+
+/**
+ * The HTTP response from Maven Central
+ *
+ * @param response the response from Maven Central
+ */
+public record MavenCentralResponse(Response response) {}

--- a/src/main/java/com/giovds/dto/Response.java
+++ b/src/main/java/com/giovds/dto/Response.java
@@ -1,0 +1,10 @@
+package com.giovds.dto;
+
+import java.util.List;
+
+/**
+ * The dependencies and pagination information from Maven Central
+ *
+ * @param docs the dependencies from Maven Central
+ */
+public record Response(List<DependencyResponse> docs) {}


### PR DESCRIPTION
### Overview
This pull request addresses the issue related to Jackson JR record deserialization in the `QueryClient` class.

### Changes Made
- Removed manual mapping for the `FoundDependency` record due to the availability of built-in record deserialization in Jackson JR version 2.18.
- Updated the `FoundDependency` record to utilize direct deserialization from the response.
- Fixed issues related to variable assignment in the `FoundDependency` record constructor.

### Testing
- Unit tests have been updated to verify the functionality of record deserialization.
- All tests pass successfully.

### Related Issues
This pull request closes issues: 
- #60 

Pls let me know if I can improve anywhere or do something more 🙂